### PR TITLE
External DNS

### DIFF
--- a/manifests/examples/alb_ingress/external_dns.yaml
+++ b/manifests/examples/alb_ingress/external_dns.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: external-dns
   namespace: kube-system
+  labels:
+    app: external-dns
 spec:
   strategy:
     type: Recreate
@@ -12,13 +14,57 @@ spec:
         app: external-dns
     spec:
       containers:
-      - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.2
-        args:
-        - --source=service
-        - --source=ingress
-        - --domain-filter=dti.nuk-kube-dev.ntch.co.uk # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
-        - --provider=aws
-        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
-        - --registry=txt
-        - --txt-owner-id=my-identifier
+        - name: external-dns
+          image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
+          args:
+          - --source=service
+          - --source=ingress
+          - --domain-filter=scratch.mojanalytics.xyz # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+          - --provider=aws
+          - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+          - --registry=txt
+          - --txt-owner-id=my-identifier
+      serviceAccountName: external-dns
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+  - apiGroups: ["", "extensions"]
+    resources:
+      - services
+      - ingresses
+    verbs:
+      - get
+      - watch
+      - list
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: kube-system
+  labels:
+    app: external-dns
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: kube-system
+
+

--- a/manifests/jobs/job-release.yaml
+++ b/manifests/jobs/job-release.yaml
@@ -10,6 +10,6 @@ spec:
     spec:
       containers:
         - name: ubuntu-release
-          image: ubuntu
-          command: ["lsb_release", "-a"]
+          image: ubuntu:14.04
+          command: ["/usr/bin/lsb_release", "-a"]
       restartPolicy: Never


### PR DESCRIPTION
External DNS with RBAC support

updated image tag for ubuntu.  `lsb_release` does not work with Xenial